### PR TITLE
Fix resolver returning undefined arguments to cb()

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class VirtualModulePlugin {
         return;
       }
 
-      resolved.then(cb);
+      resolved.then(() => cb());
     }
 
     if (!compiler.resolvers.normal) {


### PR DESCRIPTION
Currently, when resolving the `resolved` promise, the `argument`s passed to `cb` contains an argument with `undefined` as the first argument, like so:

![image](https://user-images.githubusercontent.com/600962/27812533-794c8cea-6024-11e7-93df-dadb4b7c827d.png)

This causes an issue with the enhanced-resolver in webpack. Particularly this line here: https://github.com/webpack/enhanced-resolve/blob/master/lib/Resolver.js#L128

Because arguments.length is > 0, this causes the callback to be called, instead of the `resolver.applyPluginsAsyncSeriesBailResult1` being called, which means `after-resolve` never gets called in the plugin chain, causing other things in webpack to break.

This fix just makes sure cb() gets called with no arguments.