### PR TITLE
Fix deprecation warning in webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,15 @@ class VirtualModulePlugin {
     function addPlugin() {
       const useModuleFactory = !compiler.resolvers.normal.plugin;
       if (useModuleFactory) {
-        compiler.plugin('normal-module-factory', (nmf) => {
-          nmf.plugin('before-resolve', resolverPlugin);
-        });
+        if (compiler.hooks) {
+          compiler.hooks.normalModuleFactory.tap('VirtualModulePlugin', (nmf) => {
+            nmf.hooks.beforeResolve.tap('VirtualModulePlugin', resolverPlugin);
+          });
+        } else {
+          compiler.plugin('normal-module-factory', (nmf) => {
+            nmf.plugin('before-resolve', resolverPlugin);
+          });
+        }
       } else {
         compiler.resolvers.normal.plugin('before-resolve', resolverPlugin);
       }


### PR DESCRIPTION
This solves the problem where webpack warns about the deprecation of `Tapable.plugin`. 

Code has been tested against all examples and works as expected.

**Before when running against webpack 4 example**
```
(node:18843) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
Hash: 219dc48082e1f794dbc1
Version: webpack 4.1.0
Time: 491ms
Built at: 2018-12-12 16:51:09
       Asset      Size  Chunks             Chunk Names
    index.js  8.25 KiB   index  [emitted]  index
index.js.map  7.19 KiB   index  [emitted]  index
Entrypoint index = index.js index.js.map
[./src/css/generated.css] 690 bytes {index} [built]
[./src/greeting/index.js] 166 bytes {index} [built]
[./src/index.js] 405 bytes {index} [built]
[./src/mysettings.js] 59 bytes {index} [built]
    + 1 hidden module
✨  Done in 1.48s.
```

**After when running against webpack 4 example**
```
Hash: 219dc48082e1f794dbc1
Version: webpack 4.1.0
Time: 402ms
Built at: 2018-12-12 16:52:26
       Asset      Size  Chunks             Chunk Names
    index.js  8.25 KiB   index  [emitted]  index
index.js.map  7.19 KiB   index  [emitted]  index
Entrypoint index = index.js index.js.map
[./src/css/generated.css] 690 bytes {index} [built]
[./src/greeting/index.js] 166 bytes {index} [built]
[./src/index.js] 405 bytes {index} [built]
[./src/mysettings.js] 59 bytes {index} [built]
    + 1 hidden module
✨  Done in 1.14s.
```